### PR TITLE
fix: no dependent calcs when src doesn't change

### DIFF
--- a/src/town/lilac/flex.cljc
+++ b/src/town/lilac/flex.cljc
@@ -95,11 +95,14 @@
   (-discard [_ tx-id]
     (set! txs (dissoc txs tx-id)))
   (-commit [_ tx-id]
-    (set! value (get txs tx-id))
-    (set! txs (dissoc txs tx-id))
-    ;; TODO ensure that tx-id is monotonic
-    (set! commit tx-id)
-    dependents)
+    (let [new-val (get txs tx-id)
+          val-change? (not= value new-val)]
+      (set! value (get txs tx-id))
+      (set! txs (dissoc txs tx-id))
+      ;; TODO ensure that tx-id is monotonic
+      (set! commit tx-id)
+      (when val-change?
+        dependents)))
   (-rebase [_ parent-id child-id]
     (set! txs (assoc txs parent-id (get txs child-id))))
   #?(:clj clojure.lang.IDeref :cljs IDeref)

--- a/test/town/lilac/flex_test.cljc
+++ b/test/town/lilac/flex_test.cljc
@@ -391,5 +391,12 @@
         fx (f/effect [] (prn @B))]
     ))
 
+(deftest listener-on-source
+  (let [a (f/source 0)
+        *calls (atom 0)]
+    (f/listen a (fn [_] (swap! *calls inc)))
+    (a 0)
+    (is (zero? @*calls) "Needlessly called listen function")))
+
 (comment
   (t/run-tests))


### PR DESCRIPTION
Fixes an issue where a direct listener on a source would needlessly run even if the source didn't change.