### PR TITLE
bump: new libraries versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,13 +6,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3.4.0
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '11'
-      - uses: DeLaGuardo/setup-clojure@master
+          java-version: '21'
+      - uses: DeLaGuardo/setup-clojure@13.4
         with:
-          cli: '1.11.1.1155'
+          cli: '1.12.0.1530'
       - name: Cache clojure dependencies
         uses: actions/cache@v3
         with:
@@ -23,9 +23,9 @@ jobs:
           key: cljdeps-${{ hashFiles('deps.edn') }}
           restore-keys: cljdeps-
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
       - name: Run Clojure tests
         run: clojure -X:test-clj
       - name: Run ClojureScript tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: Project tests
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   project-tests:
     runs-on: ubuntu-latest

--- a/deps.edn
+++ b/deps.edn
@@ -9,5 +9,5 @@
             :exec-fn cognitect.test-runner.api/test}
            :test-cljs
            {:extra-paths ["test"]
-            :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}
+            :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.1"}}
             :main-opts ["-m" "cljs-test-runner.main"]}}}


### PR DESCRIPTION
This PR aims to bump a lib.

Minor updates:
- olical/cljs-test-runner from `3.8.0` to `3.8.1`

Also:
- Updates `ci.yml` file to build and run ci tests